### PR TITLE
Addressing some comments received during 6MAN@IETF121

### DIFF
--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -350,7 +350,61 @@ This is to align the Router Lifetime with the recommendations in <xref target="R
 
 <section title="Honor Small PIO Valid Lifetimes" anchor="sig-stale-config">
 
-<t>The entire item "e)" (pp. 19-20) from Section 5.5.3 of <xref target="RFC4862"/> is replaced with the following text:
+<t>This document introduces the following update to Section 5.5.3 of <xref target="RFC4862"/>:</t>
+
+<t>OLD TEXT:</t>
+<t>=======</t>
+<t>
+e)  If the advertised prefix is equal to the prefix of an address
+      configured by stateless autoconfiguration in the list, the
+      preferred lifetime of the address is reset to the Preferred
+      Lifetime in the received advertisement.  The specific action to
+      perform for the valid lifetime of the address depends on the Valid
+      Lifetime in the received advertisement and the remaining time to
+      the valid lifetime expiration of the previously autoconfigured
+      address.  We call the remaining time "RemainingLifetime" in the
+      following discussion:
+</t>
+<t>
+<list style="hanging">
+<t>
+1. If the received Valid Lifetime is greater than 2 hours or greater than RemainingLifetime, set the valid lifetime of the corresponding address to the advertised Valid Lifetime.
+</t>
+<t>
+2. If RemainingLifetime is less than or equal to 2 hours, ignore the Prefix Information option with regards to the valid lifetime, unless the Router Advertisement from which this option was obtained has been authenticated (e.g., via Secure Neighbor Discovery <xref target="RFC3971"/>).  If the Router Advertisement was authenticated, the valid lifetime of the corresponding address should be set to the Valid Lifetime in the received option.
+</t>
+<t>
+3. Otherwise, reset the valid lifetime of the corresponding address to 2 hours.
+</t>
+</list>
+</t>
+<t>
+The above rules address a specific denial-of-service attack in
+      which a bogus advertisement could contain prefixes with very small
+      Valid Lifetimes.  Without the above rules, a single
+      unauthenticated advertisement containing bogus Prefix Information
+      options with short Valid Lifetimes could cause all of a node's
+      addresses to expire prematurely.  The above rules ensure that
+      legitimate advertisements (which are sent periodically) will
+      "cancel" the short Valid Lifetimes before they actually take
+      effect.
+</t>
+<t>
+      Note that the preferred lifetime of the corresponding address is
+      always reset to the Preferred Lifetime in the received Prefix
+      Information option, regardless of whether the valid lifetime is
+      also reset or ignored.  The difference comes from the fact that
+      the possible attack for the preferred lifetime is relatively
+      minor.  Additionally, it is even undesirable to ignore the
+      preferred lifetime when a valid administrator wants to deprecate a
+      particular address by sending a short preferred lifetime (and the
+      valid lifetime is ignored by accident).
+</t>
+<t>=======</t>
+
+<t>NEW TEXT:</t>
+<t>=======</t>
+<t>
 <list style="hanging">
 <t>e)  If the advertised prefix is equal to the prefix of an address
       configured by stateless autoconfiguration in the list, the
@@ -360,18 +414,20 @@ This is to align the Router Lifetime with the recommendations in <xref target="R
 </t>
 </list>
 </t>
-
-
-
-
-
+<t>
+While allowing updates to the valid lifetime in RAs could enable an attacker to invalidate addresses by setting the valid lifetime to zero, this doesn't significantly worsen the security situation. An attacker capable of sending rogue RAs already has the power to disrupt connectivity by manipulating other parameters, such as gateway or DNS information.  Therefore, accepting a zero lifetime doesn't make the system more vulnerable than it already is in the presence of such an attacker.
+</t>
+<t>
+In scenarios where RA-based attacks are of concern, proper mitigations such as RA-Guard <xref target="RFC6105"/> <xref target="RFC7113"/> or SEND <xref target="RFC3971"/> should be implemented. 
+</t>
+<t>=======</t>
 
 <t>
 <list style="hanging">
 <t hangText="RATIONALE:">
 <list style="symbols">
 <t>
-This change allows hosts to react to the signal provided by a router that has positive knowledge that a prefix has become invalid.
+This change allows hosts to react to the signal provided by a router that has positive knowledge that a prefix is not assigned to the given link anymore. In particular it would allow the host to invalidate addresses from that prefix, and, if the prefix is reassigned to another link, allows the host to communicate to devices on that link.
 </t>
 <t>
 The behavior described in <xref target="RFC4862"/> had been incorporated during
@@ -383,11 +439,8 @@ The behavior described in <xref target="RFC4862"/> had been incorporated during
          risk than other ND-based attack vectors <xref target="IPNG-minutes"/>.
 <vspace blankLines="1" />
          While reconsidering the trade-offs represented by such
-         decision, we conclude that the drawbacks of the aforementioned mitigation outweigh the possible benefits.
+         decision, we conclude that the drawbacks of the aforementioned mitigation outweigh the possible benefits, as specified in the updated text.
 <vspace blankLines="1" />
-         In scenarios where RA-based attacks are of concern, proper
-         mitigations such as RA-Guard <xref target="RFC6105"/> <xref target="RFC7113"/> or SEND <xref target="RFC3971"/> should be
-         implemented. 
 </t>      
 
 </list>

--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -346,6 +346,44 @@ This is to align the Router Lifetime with the recommendations in <xref target="R
 </section>
 
 
+<section title="Propagating Interface Configuration Changes" anchor="init">
+
+
+<t>When the information to be contained in RAs changes (e.g. an interface is reconfigured), it is paramount that updated information is propagated to hosts connected to the corresponding network in a timely manner. Thus, this document replaces the following text from Section 6.2.4 of <xref target="RFC4861"/>:
+<list style="hanging">
+
+<t>
+
+   In such cases, the router MAY transmit up to
+   MAX_INITIAL_RTR_ADVERTISEMENTS unsolicited advertisements, using the
+   same rules as when an interface becomes an advertising interface.
+</t>
+</list>
+
+with:
+
+<list style="hanging">
+<t>
+   In such cases, the router MUST transmit 
+   MAX_INITIAL_RTR_ADVERTISEMENTS unsolicited advertisements, using the
+   same rules as when an interface becomes an advertising interface.
+</t>
+</list>
+</t>
+<t>
+<list style="hanging">
+<t hangText="RATIONALE:">
+<list style="symbols">
+<t>Use of stale information can lead to interoperability problems. Therefore, it is important that new configuration information propagates in a timelier manner to all hosts.</t>
+</list>
+</t>
+</list>
+</t>
+
+
+
+
+</section>
 
 
 <section title="Honor Small PIO Valid Lifetimes" anchor="sig-stale-config">
@@ -451,45 +489,6 @@ The behavior described in <xref target="RFC4862"/> had been incorporated during
 </section>
 
 
-<section title="Interface Initialization" anchor="init">
-
-
-
-<t>When the information to be contained in RAs changes (e.g. an interface is reconfigured), it is paramount that updated information is propagated to hosts connected to the corresponding network in a timely manner. Thus, this document replaces the following text from Section 6.2.4 of <xref target="RFC4861"/>:
-<list style="hanging">
-
-<t>
-
-   In such cases, the router MAY transmit up to
-   MAX_INITIAL_RTR_ADVERTISEMENTS unsolicited advertisements, using the
-   same rules as when an interface becomes an advertising interface.
-</t>
-</list>
-
-with:
-
-<list style="hanging">
-<t>
-   In such cases, the router MUST transmit 
-   MAX_INITIAL_RTR_ADVERTISEMENTS unsolicited advertisements, using the
-   same rules as when an interface becomes an advertising interface.
-</t>
-</list>
-</t>
-<t>
-<list style="hanging">
-<t hangText="RATIONALE:">
-<list style="symbols">
-<t>Use of stale information can lead to interoperability problems. Therefore, it is important that new configuration information propagates in a timelier manner to all hosts.</t>
-</list>
-</t>
-</list>
-</t>
-
-
-
-
-</section>
 
 
 <section title="Conveying Information in Router Advertisement (RA) Messages" anchor="ras">

--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -415,7 +415,7 @@ The above rules address a specific denial-of-service attack in
 </list>
 </t>
 <t>
-While allowing updates to the valid lifetime in RAs could enable an attacker to invalidate addresses by setting the valid lifetime to zero, this does not significantly worsen the security situation. An attacker capable of sending rogue RAs already has the power to disrupt connectivity by manipulating other parameters, such as gateway or DNS information.  Therefore, accepting a zero lifetime does not make the system more vulnerable than it already is, as invalidating the prefix is just one of the many vectors available to perform DoS attacks to on-link node, see <xref target="RFC3756"/>.
+While allowing updates to the valid lifetime in RAs could enable an attacker to invalidate addresses by setting the valid lifetime to zero, this does not significantly worsen the security situation. An attacker capable of sending rogue RAs already has the power to disrupt connectivity by manipulating other parameters, such as gateway or DNS information.  Therefore, accepting a zero lifetime does not make the system more vulnerable than it already is, as invalidating the prefix is just one of the many vectors available to perform DoS attacks to on-link node (see <xref target="RFC3756"/>).
 </t>
 <t>
 In scenarios where RA-based attacks are of concern, mitigations such as RA-Guard <xref target="RFC6105"/> <xref target="RFC7113"/> or SEND <xref target="RFC3971"/> should be implemented. 

--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -353,8 +353,11 @@ This is to align the Router Lifetime with the recommendations in <xref target="R
 <list style="hanging">
 
 <t>
-
-   In such cases, the router MAY transmit up to
+   The information contained in Router Advertisements may change through
+   actions of system management.  For instance, the lifetime of
+   advertised prefixes may change, new prefixes could be added, a router
+   could cease to be a router (i.e., switch from being a router to being
+   a host), etc.  In such cases, the router MAY transmit up to
    MAX_INITIAL_RTR_ADVERTISEMENTS unsolicited advertisements, using the
    same rules as when an interface becomes an advertising interface.
 </t>
@@ -364,7 +367,13 @@ with:
 
 <list style="hanging">
 <t>
-   In such cases, the router MUST transmit 
+   The information contained in Router Advertisements may change through
+   actions of system management, or because it is derived from information
+   learned from an upstream router (via e.g. DHCPv6 [RFC8415]), and such 
+   information has changed. For instance, the lifetime of advertised prefixes may 
+   change, new prefixes could be added, existing prefixes could be removed,
+   a router could cease to be a router (i.e., switch from being a router to being
+   a host), etc.  In such cases, the router MUST transmit 
    MAX_INITIAL_RTR_ADVERTISEMENTS unsolicited advertisements, using the
    same rules as when an interface becomes an advertising interface.
 </t>

--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -402,7 +402,7 @@ The behavior described in <xref target="RFC4862"/> had been incorporated during
 
 
 
-<t>When an interface is initialized or reconfigured, it is paramount that network configuration information is propagated on the corresponding network in a timely manner. Thus, this document replaces the following text from Section 6.2.4 of <xref target="RFC4861"/>:
+<t>When the information contained in RAs changes (e.g. an interface is reconfigured), it is paramount that updated information is propagated to hosts connected to the corresponding network in a timely manner. Thus, this document replaces the following text from Section 6.2.4 of <xref target="RFC4861"/>:
 <list style="hanging">
 
 <t>

--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -961,6 +961,10 @@ P = 1 - (Loss)^n
             <td align="center">0.40</td>
             <td align="center">0.50</td>
             <td align="center">0.60</td>
+            <td align="center">0.70</td>
+            <td align="center">0.80</td>
+            <td align="center">0.90</td>
+            <td align="center">0.96</td>
           </tr>      
       	  <tr>
             <td align="center">3</td>
@@ -970,6 +974,10 @@ P = 1 - (Loss)^n
             <td align="center">0.93600</td>
             <td align="center">0.87500</td>
             <td align="center">0.78400</td>
+            <td align="center">0.65700</td>
+            <td align="center">0.48800</td>
+            <td align="center">0.27100</td>
+            <td align="center">0.14263</td>
           </tr> 
       	  <tr>
             <td align="center">4</td>
@@ -979,6 +987,10 @@ P = 1 - (Loss)^n
             <td align="center">0.97440</td>
             <td align="center">0.93750</td>
             <td align="center">0.87040</td>
+            <td align="center">0.75990</td>
+            <td align="center">0.59040</td>
+            <td align="center">0.34390</td>
+            <td align="center">0.18549</td>
           </tr> 
       	  <tr>
             <td align="center">5</td>
@@ -988,6 +1000,10 @@ P = 1 - (Loss)^n
             <td align="center">0.98976</td>
             <td align="center">0.96875</td>
             <td align="center">0.92224</td>
+            <td align="center">0.83193</td>
+            <td align="center">0.67232</td>
+            <td align="center">0.40951</td>
+            <td align="center">0.46856</td>
           </tr> 
       	  <tr>
             <td align="center">6</td>
@@ -997,6 +1013,10 @@ P = 1 - (Loss)^n
             <td align="center">0.99590</td>
             <td align="center">0.98437</td>
             <td align="center">0.95334</td>
+            <td align="center">0.88235</td>
+            <td align="center">0.73786</td>
+            <td align="center">0.46856</td>
+            <td align="center">0.26491</td>
           </tr> 
       	  <tr>
             <td align="center">7</td>
@@ -1006,6 +1026,10 @@ P = 1 - (Loss)^n
             <td align="center">0.99836</td>
             <td align="center">0.99219</td>
             <td align="center">0.97201</td>
+            <td align="center">0.91765</td>
+            <td align="center">0.79028</td>
+            <td align="center">0.52170</td>
+            <td align="center">0.30166</td>
           </tr> 
       	  <tr>
             <td align="center">8</td>
@@ -1015,6 +1039,10 @@ P = 1 - (Loss)^n
             <td align="center">0.99934</td>
             <td align="center">0.99609</td>
             <td align="center">0.98320</td>
+            <td align="center">0.94235</td>
+            <td align="center">0.83223</td>
+            <td align="center">0.56953</td>
+            <td align="center">0.33658</td>
           </tr> 
       	  <tr>
             <td align="center">9</td>
@@ -1024,6 +1052,10 @@ P = 1 - (Loss)^n
             <td align="center">0.99974</td>
             <td align="center">0.99805</td>
             <td align="center">0.98992</td>
+            <td align="center">0.95965</td>
+            <td align="center">0.86578</td>
+            <td align="center">0.61258</td>
+            <td align="center">0.36975</td>
           </tr> 
       	  <tr>
             <td align="center">10</td>
@@ -1033,6 +1065,10 @@ P = 1 - (Loss)^n
             <td align="center">0.99989</td>
             <td align="center">0.99902</td>
             <td align="center">0.99395</td>
+            <td align="center">0.97175</td>
+            <td align="center">0.89263</td>
+            <td align="center">0.65132</td>
+            <td align="center">0.40126</td>
           </tr> 
                  </tbody>
 </table>

--- a/draft-ietf-6man-slaac-renum-08.xml
+++ b/draft-ietf-6man-slaac-renum-08.xml
@@ -415,10 +415,10 @@ The above rules address a specific denial-of-service attack in
 </list>
 </t>
 <t>
-While allowing updates to the valid lifetime in RAs could enable an attacker to invalidate addresses by setting the valid lifetime to zero, this doesn't significantly worsen the security situation. An attacker capable of sending rogue RAs already has the power to disrupt connectivity by manipulating other parameters, such as gateway or DNS information.  Therefore, accepting a zero lifetime doesn't make the system more vulnerable than it already is in the presence of such an attacker.
+While allowing updates to the valid lifetime in RAs could enable an attacker to invalidate addresses by setting the valid lifetime to zero, this does not significantly worsen the security situation. An attacker capable of sending rogue RAs already has the power to disrupt connectivity by manipulating other parameters, such as gateway or DNS information.  Therefore, accepting a zero lifetime does not make the system more vulnerable than it already is, as invalidating the prefix is just one of the many vectors available to perform DoS attacks to on-link node, see <xref target="RFC3756"/>.
 </t>
 <t>
-In scenarios where RA-based attacks are of concern, proper mitigations such as RA-Guard <xref target="RFC6105"/> <xref target="RFC7113"/> or SEND <xref target="RFC3971"/> should be implemented. 
+In scenarios where RA-based attacks are of concern, mitigations such as RA-Guard <xref target="RFC6105"/> <xref target="RFC7113"/> or SEND <xref target="RFC3971"/> should be implemented. 
 </t>
 <t>=======</t>
 
@@ -455,7 +455,7 @@ The behavior described in <xref target="RFC4862"/> had been incorporated during
 
 
 
-<t>When the information contained in RAs changes (e.g. an interface is reconfigured), it is paramount that updated information is propagated to hosts connected to the corresponding network in a timely manner. Thus, this document replaces the following text from Section 6.2.4 of <xref target="RFC4861"/>:
+<t>When the information to be contained in RAs changes (e.g. an interface is reconfigured), it is paramount that updated information is propagated to hosts connected to the corresponding network in a timely manner. Thus, this document replaces the following text from Section 6.2.4 of <xref target="RFC4861"/>:
 <list style="hanging">
 
 <t>
@@ -692,6 +692,7 @@ This document has no actions for IANA.
 	<?rfc include="reference.RFC.3971" ?>
 	<!-- DHCPv6 -->
 	<?rfc include="reference.RFC.8415" ?>
+	<?rfc include="reference.RFC.3756" ?>
 	<!-- VRRPv3 -->
 	<?rfc include="reference.RFC.9568" ?>
 


### PR DESCRIPTION
- Clarify the text about sending unsolicited RAs upon network config changes
-  Add more loss values to the table (0.7, 0.8, 0.9, 0.95)
- For the "valid lifetime < 2hrs" update:
  -- change the section to the "old text/new text format, so it's easier to read
  -- modify what text to remove (we need to delete more text from 4862)
  -- add some clarification about the threat model (as the original text contained it), as per Suresh's and Tim's comments.
  -- clarify the rationale to explain why the prefix needs to be invalidated.